### PR TITLE
ISSUE6: get paragraph number from Num attribute instead of ParagraphNum element

### DIFF
--- a/lawhub/law.py
+++ b/lawhub/law.py
@@ -194,7 +194,7 @@ class Paragraph(BaseLawClass):
         assert node.tag == 'Paragraph'
         assert node[0].tag == 'ParagraphNum'
         assert node[1].tag == 'ParagraphSentence'
-        self.num = int(node[0].text) if node[0].text else None
+        self.num = int(node.attrib['Num']) if 'Num' in node.attrib else None
         self.sentence = extract_text_from_sentence(node[1][0])
         self.children = [parse(child) for child in node[2:]]
 


### PR DESCRIPTION
resolved #6 
applied to additional 11 files

```
APPLY success: 79.40 % (420/529 for 151 files)
APPLY success: 80.10 % (471/588 for 162 files)
```

```
12/07/2019 06:53:58 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/kakuhou/200/11/58.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:02 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/kakuhou/200/11/37.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:03 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/kakuhou/200/11/17.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:10 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/kakuhou/200/11/57.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:28 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/syuhou/198/32/0.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:38 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/syuhou/196/30/0.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:39 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/syuhou/196/30/1.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:47 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/syuhou/196/40/0.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:48 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/syuhou/196/22/0.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:51 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/syuhou/197/3/1.xml: invalid literal for int() with base 10: '○２'
12/07/2019 06:54:56 - apply_gian - ERROR - failed to parse /Users/musui/lawhub/lawhub-spider/data/sanhou/200/10/0.xml: invalid literal for int() with base 10: '○２'

```