### PR TITLE
ISSUE40: throw exception when multiple target text found

### DIFF
--- a/lawhub/apply.py
+++ b/lawhub/apply.py
@@ -22,6 +22,15 @@ class TextNotFoundError(Exception):
         return f'{self.text} does not exist in {self.query}'
 
 
+class MultipleTextFoundError(Exception):
+    def __init__(self, text, query):
+        self.text = text
+        self.query = query
+
+    def __str__(self):
+        return f'found {self.text} multiple times in {self.query}'
+
+
 def apply_replace(action, query2node):
     if action.action_type != ActionType.REPLACE:
         raise ValueError(f'apply_replace() is called with invalid ActionType: {action.action_type}')
@@ -30,6 +39,8 @@ def apply_replace(action, query2node):
     node = query2node[action.at]
     if not (hasattr(node, 'sentence')) or action.old not in node.sentence:
         raise TextNotFoundError(action.old, action.at)
+    if node.sentence.count(action.old) > 1:
+        raise MultipleTextFoundError(action.old, action.at)
     node.sentence = node.sentence.replace(action.old, action.new)
     LOGGER.debug(f'replaced \"{action.old}\" in {action.at} to \"{action.new}\"')
 
@@ -42,6 +53,8 @@ def apply_add_after(action, query2node):
     node = query2node[action.at]
     if not (hasattr(node, 'sentence')) or action.word not in node.sentence:
         raise TextNotFoundError(action.word, action.at)
+    if node.sentence.count(action.word) > 1:
+        raise MultipleTextFoundError(action.word, action.at)
     idx = node.sentence.find(action.word) + len(action.word)
     node.sentence = node.sentence[:idx] + action.what + node.sentence[idx:]
     LOGGER.debug(f'added \"{action.what}\" at {action.at}')
@@ -56,8 +69,11 @@ def apply_delete(action, query2node):
     if not (hasattr(node, 'sentence')):
         raise TextNotFoundError('', action.at)
     for what in action.whats:
-        if what not in node.sentence:
+        count = node.sentence.count(what)
+        if count == 0:
             raise TextNotFoundError(what, action.at)
+        elif count > 1:
+            raise MultipleTextFoundError(what, action.at)
     for what in action.whats:
         node.sentence = node.sentence.replace(what, '')
         LOGGER.debug(f'deleted \"{what}\" in {action.at}')

--- a/tests/test_apply.py
+++ b/tests/test_apply.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from lawhub.action import Action
-from lawhub.apply import apply_replace, TextNotFoundError, apply_add_after, apply_delete
+from lawhub.apply import apply_replace, TextNotFoundError, MultipleTextFoundError, apply_add_after, apply_delete
 from lawhub.law import Paragraph
 from lawhub.query import Query
 
@@ -21,6 +21,14 @@ class TestApply(TestCase):
         action = Action('第一項中「サル」を「イヌ」に改める')
 
         with self.assertRaises(TextNotFoundError):
+            apply_replace(action, query2node)
+
+    def test_apply_replace_multiple_fail(self):
+        node = Paragraph(title='第一項', sentence='私はネコネコです')
+        query2node = {Query('第一項'): node}
+        action = Action('第一項中「ネコ」を「イヌ」に改める')
+
+        with self.assertRaises(MultipleTextFoundError):
             apply_replace(action, query2node)
 
     def test_add_after(self):


### PR DESCRIPTION
resolve #40 

apply rate decreased by 5%. In other words, we can increase apply rate by 5% if we correctly handle multiple occurence

```
[musui@local lawhub-tool]$ ./report.py 
TOTAL success: 45.55 % (2,817/6,185 for 166 files)
PARSE success: 70.24 % (5,445/7,752 for 219 files)
APPLY success: 85.39 % (2,817/3,299 for 166 files)

[musui@local lawhub-tool]$ ./report.py 
TOTAL success: 42.68 % (2,640/6,185 for 166 files)
PARSE success: 70.24 % (5,445/7,752 for 219 files)
APPLY success: 80.02 % (2,640/3,299 for 166 files)

```